### PR TITLE
Fix non-sequential order

### DIFF
--- a/src/main/java/org/crochet/mapper/FileMapper.java
+++ b/src/main/java/org/crochet/mapper/FileMapper.java
@@ -7,14 +7,14 @@ import org.mapstruct.ReportingPolicy;
 import org.mapstruct.factory.Mappers;
 
 import java.util.Collection;
-import java.util.Set;
+import java.util.List;
 
 @Mapper(unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface FileMapper {
     FileMapper INSTANCE = Mappers.getMapper(FileMapper.class);
 
     File toEntity(FileResponse fileResponse);
-    Set<File> toEntities(Collection<FileResponse> fileResponses);
+    List<File> toEntities(Collection<FileResponse> fileResponses);
 
     FileResponse toResponse(File file);
 }

--- a/src/main/java/org/crochet/mapper/ImageMapper.java
+++ b/src/main/java/org/crochet/mapper/ImageMapper.java
@@ -1,6 +1,5 @@
 package org.crochet.mapper;
 
-import org.crochet.model.File;
 import org.crochet.model.Image;
 import org.crochet.payload.response.FileResponse;
 import org.mapstruct.Mapper;
@@ -8,14 +7,14 @@ import org.mapstruct.ReportingPolicy;
 import org.mapstruct.factory.Mappers;
 
 import java.util.Collection;
-import java.util.Set;
+import java.util.List;
 
 @Mapper(unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface ImageMapper {
     ImageMapper INSTANCE = Mappers.getMapper(ImageMapper.class);
 
     Image toEntity(FileResponse fileResponse);
-    Set<Image> toEntities(Collection<FileResponse> fileResponses);
+    List<Image> toEntities(Collection<FileResponse> fileResponses);
 
     FileResponse toResponse(Image image);
 }

--- a/src/main/java/org/crochet/model/BlogPost.java
+++ b/src/main/java/org/crochet/model/BlogPost.java
@@ -18,7 +18,6 @@ import lombok.experimental.SuperBuilder;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Set;
 import java.util.UUID;
 
 @Getter
@@ -44,7 +43,7 @@ public class BlogPost {
     private LocalDateTime creationDate;
 
     @OneToMany(mappedBy = "blogPost")
-    private Set<Comment> comments;
+    private List<Comment> comments;
 
     @ElementCollection
     @CollectionTable(name = "blog_post_file",

--- a/src/main/java/org/crochet/model/Category.java
+++ b/src/main/java/org/crochet/model/Category.java
@@ -1,12 +1,18 @@
 package org.crochet.model;
 
-import jakarta.persistence.*;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 
-import java.util.Set;
+import java.util.List;
 
 @Getter
 @Setter
@@ -23,14 +29,14 @@ public class Category extends BaseEntity {
     private Category parent;
 
     @OneToMany(mappedBy = "parent", cascade = CascadeType.REMOVE, orphanRemoval = true)
-    private Set<Category> children;
+    private List<Category> children;
 
     @OneToMany(mappedBy = "category", cascade = CascadeType.ALL)
-    private Set<Product> products;
+    private List<Product> products;
 
     @OneToMany(mappedBy = "category", cascade = CascadeType.ALL)
-    private Set<Pattern> patterns;
+    private List<Pattern> patterns;
 
     @OneToMany(mappedBy = "category", cascade = CascadeType.ALL)
-    private Set<FreePattern> freePatterns;
+    private List<FreePattern> freePatterns;
 }

--- a/src/main/java/org/crochet/model/FreePattern.java
+++ b/src/main/java/org/crochet/model/FreePattern.java
@@ -1,12 +1,20 @@
 package org.crochet.model;
 
-import jakarta.persistence.*;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Lob;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 
-import java.util.Set;
+import java.util.List;
 
 @Getter
 @Setter
@@ -30,8 +38,8 @@ public class FreePattern extends BaseEntity {
     private Category category;
 
     @OneToMany(mappedBy = "freePattern", cascade = CascadeType.ALL)
-    private Set<File> files;
+    private List<File> files;
 
     @OneToMany(mappedBy = "freePattern", cascade = CascadeType.ALL)
-    private Set<Image> images;
+    private List<Image> images;
 }

--- a/src/main/java/org/crochet/model/Pattern.java
+++ b/src/main/java/org/crochet/model/Pattern.java
@@ -1,6 +1,16 @@
 package org.crochet.model;
 
-import jakarta.persistence.*;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Lob;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -8,7 +18,6 @@ import lombok.experimental.SuperBuilder;
 import org.crochet.enumerator.CurrencyCode;
 
 import java.util.List;
-import java.util.Set;
 
 @Getter
 @Setter
@@ -36,15 +45,15 @@ public class Pattern extends BaseEntity {
     private CurrencyCode currencyCode;
 
     @OneToMany(mappedBy = "pattern", cascade = CascadeType.ALL)
-    private Set<OrderPatternDetail> orderPatternDetails;
+    private List<OrderPatternDetail> orderPatternDetails;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "category_id", columnDefinition = "BINARY(16) NOT NULL")
     private Category category;
 
     @OneToMany(mappedBy = "pattern", cascade = CascadeType.ALL)
-    private Set<File> files;
+    private List<File> files;
 
     @OneToMany(mappedBy = "pattern", cascade = CascadeType.ALL)
-    private Set<Image> images;
+    private List<Image> images;
 }

--- a/src/main/java/org/crochet/model/Product.java
+++ b/src/main/java/org/crochet/model/Product.java
@@ -1,13 +1,23 @@
 package org.crochet.model;
 
-import jakarta.persistence.*;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Lob;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 import org.crochet.enumerator.CurrencyCode;
 
-import java.util.Set;
+import java.util.List;
 
 @Getter
 @Setter
@@ -37,5 +47,5 @@ public class Product extends BaseEntity {
     private Category category;
 
     @OneToMany(mappedBy = "product", cascade = CascadeType.ALL)
-    private Set<File> files;
+    private List<File> files;
 }

--- a/src/main/java/org/crochet/model/User.java
+++ b/src/main/java/org/crochet/model/User.java
@@ -18,7 +18,7 @@ import lombok.experimental.SuperBuilder;
 import org.crochet.enumerator.AuthProvider;
 import org.crochet.enumerator.RoleType;
 
-import java.util.Set;
+import java.util.List;
 
 @Entity
 @Table(name = "users", uniqueConstraints = {
@@ -63,17 +63,17 @@ public class User extends BaseEntity {
     private RoleType role = RoleType.USER;
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
-    private Set<ConfirmationToken> confirmationTokens;
+    private List<ConfirmationToken> confirmationTokens;
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
-    private Set<PasswordResetToken> passwordResetTokens;
+    private List<PasswordResetToken> passwordResetTokens;
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
-    private Set<Comment> comments;
+    private List<Comment> comments;
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
-    private Set<Order> orders;
+    private List<Order> orders;
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
-    private Set<RefreshToken> refreshTokens;
+    private List<RefreshToken> refreshTokens;
 }

--- a/src/main/java/org/crochet/payload/request/FreePatternRequest.java
+++ b/src/main/java/org/crochet/payload/request/FreePatternRequest.java
@@ -5,7 +5,7 @@ import lombok.Builder;
 import lombok.Data;
 import org.crochet.payload.response.FileResponse;
 
-import java.util.Set;
+import java.util.List;
 import java.util.UUID;
 
 @Data
@@ -17,6 +17,6 @@ public class FreePatternRequest {
     private String name;
     private String description;
     private String author;
-    private Set<FileResponse> images;
-    private Set<FileResponse> files;
+    private List<FileResponse> images;
+    private List<FileResponse> files;
 }

--- a/src/main/java/org/crochet/payload/request/PatternRequest.java
+++ b/src/main/java/org/crochet/payload/request/PatternRequest.java
@@ -6,7 +6,7 @@ import lombok.Data;
 import org.crochet.enumerator.CurrencyCode;
 import org.crochet.payload.response.FileResponse;
 
-import java.util.Set;
+import java.util.List;
 import java.util.UUID;
 
 @Data
@@ -20,6 +20,6 @@ public class PatternRequest {
     private double price;
     @JsonProperty("currency_code")
     private CurrencyCode currencyCode;
-    private Set<FileResponse> images;
-    private Set<FileResponse> files;
+    private List<FileResponse> images;
+    private List<FileResponse> files;
 }

--- a/src/main/java/org/crochet/payload/request/ProductRequest.java
+++ b/src/main/java/org/crochet/payload/request/ProductRequest.java
@@ -6,7 +6,7 @@ import lombok.Data;
 import org.crochet.enumerator.CurrencyCode;
 import org.crochet.payload.response.FileResponse;
 
-import java.util.Set;
+import java.util.List;
 import java.util.UUID;
 
 @Data
@@ -20,5 +20,5 @@ public class ProductRequest {
     private double price;
     @JsonProperty("currency_code")
     private CurrencyCode currencyCode;
-    private Set<FileResponse> files;
+    private List<FileResponse> files;
 }

--- a/src/main/java/org/crochet/payload/response/CategoryResponse.java
+++ b/src/main/java/org/crochet/payload/response/CategoryResponse.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Getter;
 import lombok.Setter;
 
-import java.util.Set;
+import java.util.List;
 import java.util.UUID;
 
 @Getter
@@ -13,5 +13,5 @@ import java.util.UUID;
 public class CategoryResponse {
     private UUID id;
     private String name;
-    private Set<CategoryResponse> children;
+    private List<CategoryResponse> children;
 }

--- a/src/main/java/org/crochet/payload/response/FreePatternResponse.java
+++ b/src/main/java/org/crochet/payload/response/FreePatternResponse.java
@@ -3,7 +3,7 @@ package org.crochet.payload.response;
 import lombok.Builder;
 import lombok.Data;
 
-import java.util.Set;
+import java.util.List;
 
 @Data
 @Builder
@@ -12,7 +12,7 @@ public class FreePatternResponse {
     private String name;
     private String description;
     private String author;
-    private Set<FileResponse> images;
-    private Set<FileResponse> files;
+    private List<FileResponse> images;
+    private List<FileResponse> files;
     private CategoryResponse category;
 }

--- a/src/main/java/org/crochet/payload/response/PatternResponse.java
+++ b/src/main/java/org/crochet/payload/response/PatternResponse.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Data;
 
-import java.util.Set;
+import java.util.List;
 
 @Data
 @Builder
@@ -15,7 +15,7 @@ public class PatternResponse {
     private double price;
     @JsonProperty("currency_code")
     private String currencyCode;
-    private Set<FileResponse> images;
-    private Set<FileResponse> files;
+    private List<FileResponse> images;
+    private List<FileResponse> files;
     private CategoryResponse category;
 }

--- a/src/main/java/org/crochet/payload/response/ProductResponse.java
+++ b/src/main/java/org/crochet/payload/response/ProductResponse.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Data;
 
-import java.util.Set;
+import java.util.List;
 
 @Data
 @Builder
@@ -15,6 +15,6 @@ public class ProductResponse {
     private double price;
     @JsonProperty("currency_code")
     private String currencyCode;
-    private Set<FileResponse> files;
+    private List<FileResponse> files;
     private CategoryResponse category;
 }

--- a/src/main/java/org/crochet/service/impl/FreePatternServiceImpl.java
+++ b/src/main/java/org/crochet/service/impl/FreePatternServiceImpl.java
@@ -1,6 +1,5 @@
 package org.crochet.service.impl;
 
-import org.crochet.properties.MessageCodeProperties;
 import org.crochet.constant.AppConstant;
 import org.crochet.exception.ResourceNotFoundException;
 import org.crochet.mapper.FileMapper;
@@ -12,6 +11,7 @@ import org.crochet.model.Image;
 import org.crochet.payload.request.FreePatternRequest;
 import org.crochet.payload.response.FreePatternResponse;
 import org.crochet.payload.response.PaginatedFreePatternResponse;
+import org.crochet.properties.MessageCodeProperties;
 import org.crochet.repository.FreePatternRepository;
 import org.crochet.repository.FreePatternSpecifications;
 import org.crochet.service.CategoryService;
@@ -26,7 +26,6 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.ObjectUtils;
 
 import java.util.List;
-import java.util.Set;
 import java.util.UUID;
 
 import static org.crochet.constant.MessageConstant.FREE_PATTERN_NOT_FOUND_MESSAGE;
@@ -76,7 +75,7 @@ public class FreePatternServiceImpl implements FreePatternService {
 
         // Set files
         if (!ObjectUtils.isEmpty(request.getFiles())) {
-            Set<File> files = FileMapper.INSTANCE.toEntities(request.getFiles());
+            List<File> files = FileMapper.INSTANCE.toEntities(request.getFiles());
             for (var file : files) {
                 file.setFreePattern(freePattern);
             }
@@ -85,7 +84,7 @@ public class FreePatternServiceImpl implements FreePatternService {
 
         // Set images
         if (!ObjectUtils.isEmpty(request.getImages())) {
-            Set<Image> images = ImageMapper.INSTANCE.toEntities(request.getImages());
+            List<Image> images = ImageMapper.INSTANCE.toEntities(request.getImages());
             for (var image : images) {
                 image.setFreePattern(freePattern);
             }

--- a/src/main/java/org/crochet/service/impl/PatternServiceImpl.java
+++ b/src/main/java/org/crochet/service/impl/PatternServiceImpl.java
@@ -29,10 +29,11 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.ObjectUtils;
 
 import java.util.List;
-import java.util.Set;
 import java.util.UUID;
 
-import static org.crochet.constant.MessageConstant.*;
+import static org.crochet.constant.MessageConstant.PATTERN_NOT_FOUND_MESSAGE;
+import static org.crochet.constant.MessageConstant.USER_NOT_FOUND_MESSAGE;
+import static org.crochet.constant.MessageConstant.USER_NOT_PAYMENT_FOR_THIS_PATTERN_MESSAGE;
 
 /**
  * PatternServiceImpl class
@@ -72,7 +73,7 @@ public class PatternServiceImpl implements PatternService {
         pattern.setCurrencyCode(request.getCurrencyCode());
 
         if (!ObjectUtils.isEmpty(request.getFiles())) {
-            Set<File> files = FileMapper.INSTANCE.toEntities(request.getFiles());
+            List<File> files = FileMapper.INSTANCE.toEntities(request.getFiles());
             for (var file : files) {
                 file.setPattern(pattern);
             }
@@ -80,7 +81,7 @@ public class PatternServiceImpl implements PatternService {
         }
 
         if (!ObjectUtils.isEmpty(request.getImages())) {
-            Set<Image> images = ImageMapper.INSTANCE.toEntities(request.getImages());
+            List<Image> images = ImageMapper.INSTANCE.toEntities(request.getImages());
             for (var image : images) {
                 image.setPattern(pattern);
             }

--- a/src/main/java/org/crochet/service/impl/ProductServiceImpl.java
+++ b/src/main/java/org/crochet/service/impl/ProductServiceImpl.java
@@ -1,6 +1,5 @@
 package org.crochet.service.impl;
 
-import org.crochet.properties.MessageCodeProperties;
 import org.crochet.constant.AppConstant;
 import org.crochet.exception.ResourceNotFoundException;
 import org.crochet.mapper.FileMapper;
@@ -10,6 +9,7 @@ import org.crochet.model.Product;
 import org.crochet.payload.request.ProductRequest;
 import org.crochet.payload.response.ProductPaginationResponse;
 import org.crochet.payload.response.ProductResponse;
+import org.crochet.properties.MessageCodeProperties;
 import org.crochet.repository.ProductRepository;
 import org.crochet.repository.ProductSpecifications;
 import org.crochet.service.CategoryService;
@@ -24,7 +24,6 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.ObjectUtils;
 
 import java.util.List;
-import java.util.Set;
 import java.util.UUID;
 
 import static org.crochet.constant.MessageConstant.PRODUCT_NOT_FOUND_MESSAGE;
@@ -75,7 +74,7 @@ public class ProductServiceImpl implements ProductService {
         product.setCurrencyCode(request.getCurrencyCode());
 
         if (!ObjectUtils.isEmpty(request.getFiles())) {
-            Set<File> files = FileMapper.INSTANCE.toEntities(request.getFiles());
+            List<File> files = FileMapper.INSTANCE.toEntities(request.getFiles());
             for (var file : files) {
                 file.setProduct(product);
             }


### PR DESCRIPTION
This pull request fixes the non-sequential order issue in the code. It updates the `CategoryResponse`, `ProductResponse`, `BlogPost`, `FreePatternRequest`, `PatternResponse`, `PatternRequest`, `FileMapper`, `ImageMapper`, `Product`, `FreePattern`, and `User` classes to use `List` instead of `Set` for the `children`, `files`, `comments`, `images`, and `orders` fields. This ensures that the order of elements is maintained.