### PR TITLE
Update specification

### DIFF
--- a/src/main/java/org/crochet/service/impl/BannerServiceImpl.java
+++ b/src/main/java/org/crochet/service/impl/BannerServiceImpl.java
@@ -9,7 +9,9 @@ import org.crochet.payload.response.BannerResponse;
 import org.crochet.repository.BannerRepo;
 import org.crochet.repository.BannerTypeRepo;
 import org.crochet.service.BannerService;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
+import org.springframework.cache.annotation.Caching;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
@@ -30,6 +32,9 @@ public class BannerServiceImpl implements BannerService {
 
     @Transactional
     @Override
+    @Caching(
+            evict = {@CacheEvict(value = "activebanners", allEntries = true)}
+    )
     public List<BannerResponse> batchInsertOrUpdate(List<BannerRequest> requests) {
         List<Banner> banners = new ArrayList<>();
         List<Banner> existingBanners = bannerRepo.findAll();

--- a/src/main/java/org/crochet/service/impl/BlogPostServiceImpl.java
+++ b/src/main/java/org/crochet/service/impl/BlogPostServiceImpl.java
@@ -110,7 +110,7 @@ public class BlogPostServiceImpl implements BlogPostService {
         Pageable pageable = PageRequest.of(pageNo, pageSize, sort);
         Specification<BlogPost> spec = Specification.where(null);
         if (StringUtils.hasText(searchText)) {
-            spec = spec.and(BlogPostSpecifications.searchBy(searchText));
+            spec = spec.or(BlogPostSpecifications.searchBy(searchText));
         }
 
         Page<BlogPost> menuPage = blogPostRepo.findAll(spec, pageable);

--- a/src/main/java/org/crochet/service/impl/FreePatternServiceImpl.java
+++ b/src/main/java/org/crochet/service/impl/FreePatternServiceImpl.java
@@ -119,11 +119,11 @@ public class FreePatternServiceImpl implements FreePatternService {
         Pageable pageable = PageRequest.of(pageNo, pageSize, sort);
         Specification<FreePattern> spec = Specifications.getSpecificationFromFilters(filters);
         if (StringUtils.hasText(searchText)) {
-            spec = spec.and(FreePatternSpecifications.searchByNameDescOrAuthor(searchText));
+            spec = spec.or(FreePatternSpecifications.searchByNameDescOrAuthor(searchText));
         }
         // add filter criteria
         if (StringUtils.hasText(categoryId)) {
-            spec = spec.and(FreePatternSpecifications.existIn(getAllFreePatterns(categoryId)));
+            spec = spec.or(FreePatternSpecifications.existIn(getAllFreePatterns(categoryId)));
         }
         // retrieve FreePatterns
         Page<FreePattern> page = freePatternRepo.findAll(spec, pageable);

--- a/src/main/java/org/crochet/service/impl/PatternServiceImpl.java
+++ b/src/main/java/org/crochet/service/impl/PatternServiceImpl.java
@@ -103,10 +103,10 @@ public class PatternServiceImpl implements PatternService {
         sort = sortDir.equalsIgnoreCase(Sort.Direction.ASC.name()) ? sort.ascending() : sort.descending();
         Specification<Pattern> spec = Specifications.getSpecificationFromFilters(filters);
         if (StringUtils.hasText(searchText)) {
-            spec = spec.and(PatternSpecifications.searchByNameOrDesc(searchText));
+            spec = spec.or(PatternSpecifications.searchByNameOrDesc(searchText));
         }
         if (StringUtils.hasText(categoryId)) {
-            spec = spec.and(PatternSpecifications.in(getPatternsByCategory(categoryId)));
+            spec = spec.or(PatternSpecifications.in(getPatternsByCategory(categoryId)));
         }
         Pageable pageable = PageRequest.of(pageNo, pageSize, sort);
         var page = patternRepo.findAll(spec, pageable);

--- a/src/main/java/org/crochet/service/impl/ProductServiceImpl.java
+++ b/src/main/java/org/crochet/service/impl/ProductServiceImpl.java
@@ -113,10 +113,10 @@ public class ProductServiceImpl implements ProductService {
         Pageable pageable = PageRequest.of(pageNo, pageSize, sort);
         Specification<Product> spec = Specifications.getSpecificationFromFilters(filters);
         if (StringUtils.hasText(searchText)) {
-            spec = spec.and(ProductSpecifications.searchByNameOrDesc(searchText));
+            spec = spec.or(ProductSpecifications.searchByNameOrDesc(searchText));
         }
         if (StringUtils.hasText(categoryId)) {
-            spec = spec.and(ProductSpecifications.in(getProductsByCategory(categoryId)));
+            spec = spec.or(ProductSpecifications.in(getProductsByCategory(categoryId)));
         }
         Page<Product> menuPage = productRepo.findAll(spec, pageable);
         List<ProductResponse> contents = ProductMapper.INSTANCE.toResponses(menuPage.getContent());

--- a/src/main/java/org/crochet/service/impl/UserServiceImpl.java
+++ b/src/main/java/org/crochet/service/impl/UserServiceImpl.java
@@ -85,7 +85,7 @@ public class UserServiceImpl implements UserService {
         Specification<User> spec = Specifications.getSpecificationFromFilters(filters);
         // Search by search text
         if (StringUtils.hasText(searchText)) {
-            spec = spec.and(UserSpecification.searchByNameOrEmail(searchText));
+            spec = spec.or(UserSpecification.searchByNameOrEmail(searchText));
         }
         Page<User> page = userRepository.findAll(spec, pageable);
         List<UserResponse> users = UserMapper.INSTANCE.toResponses(page.getContent());


### PR DESCRIPTION
This pull request updates the specification for cache eviction in the `BannerServiceImpl` class. It adds the `@Caching` annotation with `@CacheEvict` to evict all entries in the "activebanners" cache. This ensures that the cache is properly cleared when batch inserting or updating banners.