### PR TITLE
Update cacheable annotations

### DIFF
--- a/src/main/java/org/crochet/service/impl/BlogPostServiceImpl.java
+++ b/src/main/java/org/crochet/service/impl/BlogPostServiceImpl.java
@@ -66,7 +66,10 @@ public class BlogPostServiceImpl implements BlogPostService {
     @Transactional
     @Override
     @Caching(
-            evict = {@CacheEvict(value = "limitedblogs", allEntries = true)}
+            evict = {
+                    @CacheEvict(value = "limitedblogs", allEntries = true),
+                    @CacheEvict(value = "blogs", allEntries = true)
+            }
     )
     public BlogPostResponse createOrUpdatePost(BlogPostRequest request) {
         BlogPost blogPost;
@@ -102,7 +105,9 @@ public class BlogPostServiceImpl implements BlogPostService {
      * @return A {@link BlogPostPaginationResponse} containing the paginated list of blog posts.
      */
     @Override
+    @Cacheable(value = "blogs", key = "T(java.util.Objects).hash(#pageNo, #pageSize, #sortBy, #sortDir, #searchText)")
     public BlogPostPaginationResponse getBlogs(int pageNo, int pageSize, String sortBy, String sortDir, String searchText) {
+        log.info("Fetching blog posts");
         // create Sort instance
         Sort sort = Sort.by(sortBy);
         sort = sortDir.equalsIgnoreCase(Sort.Direction.ASC.name()) ? sort.ascending() : sort.descending();
@@ -164,7 +169,12 @@ public class BlogPostServiceImpl implements BlogPostService {
      */
     @Transactional
     @Override
-    @CacheEvict(value = "limitedblogs", allEntries = true)
+    @Caching(
+            evict = {
+                    @CacheEvict(value = "limitedblogs", allEntries = true),
+                    @CacheEvict(value = "blogs", allEntries = true)
+            }
+    )
     public void deletePost(String id) {
         var blogPost = customBlogRepo.findById(id);
         blogPostRepo.delete(blogPost);

--- a/src/main/java/org/crochet/service/impl/FreePatternServiceImpl.java
+++ b/src/main/java/org/crochet/service/impl/FreePatternServiceImpl.java
@@ -68,7 +68,10 @@ public class FreePatternServiceImpl implements FreePatternService {
     @Transactional
     @Override
     @Caching(
-            evict = {@CacheEvict(value = "limitedfreepatterns", allEntries = true)}
+            evict = {
+                    @CacheEvict(value = "limitedfreepatterns", allEntries = true),
+                    @CacheEvict(value = "freepatterns", allEntries = true)
+            }
     )
     public FreePatternResponse createOrUpdate(FreePatternRequest request) {
         FreePattern freePattern;
@@ -110,8 +113,10 @@ public class FreePatternServiceImpl implements FreePatternService {
      * @return A {@link PaginatedFreePatternResponse} containing the paginated list of FreePatterns.
      */
     @Override
+    @Cacheable(value = "freepatterns", key = "T(java.util.Objects).hash(#pageNo, #pageSize, #sortBy, #sortDir, #searchText, #categoryId, #filters)")
     public PaginatedFreePatternResponse getFreePatterns(int pageNo, int pageSize, String sortBy, String sortDir,
                                                         String searchText, String categoryId, List<Filter> filters) {
+        log.info("Fetching free patterns");
         // create Sort instance
         Sort sort = Sort.by(sortBy);
         sort = sortDir.equalsIgnoreCase(Sort.Direction.ASC.name()) ? sort.ascending() : sort.descending();
@@ -186,7 +191,12 @@ public class FreePatternServiceImpl implements FreePatternService {
 
     @Transactional
     @Override
-    @CacheEvict(value = "limitedfreepatterns", allEntries = true)
+    @Caching(
+            evict = {
+                    @CacheEvict(value = "limitedfreepatterns", allEntries = true),
+                    @CacheEvict(value = "freepatterns", allEntries = true)
+            }
+    )
     public void delete(String id) {
         customFreePatternRepo.deleteById(id);
     }

--- a/src/main/java/org/crochet/service/impl/PatternServiceImpl.java
+++ b/src/main/java/org/crochet/service/impl/PatternServiceImpl.java
@@ -58,7 +58,10 @@ public class PatternServiceImpl implements PatternService {
     @Transactional
     @Override
     @Caching(
-            evict = {@CacheEvict(value = "limitedpatterns", allEntries = true)}
+            evict = {
+                    @CacheEvict(value = "limitedpatterns", allEntries = true),
+                    @CacheEvict(value = "patterns", allEntries = true)
+            }
     )
     public PatternResponse createOrUpdate(PatternRequest request) {
         Pattern pattern;
@@ -97,8 +100,10 @@ public class PatternServiceImpl implements PatternService {
      * @return Pattern is paginated
      */
     @Override
+    @Cacheable(value = "patterns", key = "T(java.util.Objects).hash(#pageNo, #pageSize, #sortBy, #sortDir, #searchText, #categoryId, #filters)")
     public PatternPaginationResponse getPatterns(int pageNo, int pageSize, String sortBy, String sortDir,
                                                  String searchText, String categoryId, List<Filter> filters) {
+        log.info("Fetching patterns");
         Sort sort = Sort.by(sortBy);
         sort = sortDir.equalsIgnoreCase(Sort.Direction.ASC.name()) ? sort.ascending() : sort.descending();
         Specification<Pattern> spec = Specifications.getSpecificationFromFilters(filters);
@@ -162,7 +167,12 @@ public class PatternServiceImpl implements PatternService {
 
     @Transactional
     @Override
-    @CacheEvict(value = "limitedpatterns", allEntries = true)
+    @Caching(
+            evict = {
+                    @CacheEvict(value = "limitedpatterns", allEntries = true),
+                    @CacheEvict(value = "patterns", allEntries = true)
+            }
+    )
     public void deletePattern(String id) {
         patternRepo.deleteById(id);
     }

--- a/src/main/java/org/crochet/service/impl/ProductServiceImpl.java
+++ b/src/main/java/org/crochet/service/impl/ProductServiceImpl.java
@@ -66,7 +66,10 @@ public class ProductServiceImpl implements ProductService {
     @Transactional
     @Override
     @Caching(
-            evict = {@CacheEvict(value = "limitedproducts", allEntries = true)}
+            evict = {
+                    @CacheEvict(value = "limitedproducts", allEntries = true),
+                    @CacheEvict(value = "products", allEntries = true)
+            }
     )
     public ProductResponse createOrUpdate(ProductRequest request) {
         Product product;
@@ -104,8 +107,10 @@ public class ProductServiceImpl implements ProductService {
      * @return A {@link ProductPaginationResponse} containing the paginated list of products.
      */
     @Override
+    @Cacheable(value = "products", key = "T(java.util.Objects).hash(#pageNo, #pageSize, #sortBy, #sortDir, #searchText, #categoryId, #filters)")
     public ProductPaginationResponse getProducts(int pageNo, int pageSize, String sortBy, String sortDir,
                                                  String searchText, String categoryId, List<Filter> filters) {
+        log.info("Fetching products");
         // create Sort instance
         Sort sort = Sort.by(sortBy);
         sort = sortDir.equalsIgnoreCase(Sort.Direction.ASC.name()) ? sort.ascending() : sort.descending();
@@ -165,7 +170,12 @@ public class ProductServiceImpl implements ProductService {
 
     @Transactional
     @Override
-    @CacheEvict(value = "limitedproducts", allEntries = true)
+    @Caching(
+            evict = {
+                    @CacheEvict(value = "limitedproducts", allEntries = true),
+                    @CacheEvict(value = "products", allEntries = true)
+            }
+    )
     public void delete(String id) {
         customProductRepo.deleteById(id);
     }


### PR DESCRIPTION
This pull request updates the cacheable annotations in several service classes. The evict cacheable annotations have been modified to include additional cache names. Additionally, the cacheable annotations have been added to the getBlogs, getFreePatterns, getPatterns, and getProducts methods to improve caching efficiency.