### PR TITLE
Remove show-sql configuration for MySQL and PostgreSQL dialects

### DIFF
--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,10 +1,8 @@
 spring:
   jpa:
-    show-sql: true
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQL8Dialect
-        format_sql: true
   datasource:
     url: jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}
     username: ${DB_USERNAME}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,10 +1,8 @@
 spring:
   jpa:
-    show-sql: true
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
-        format_sql: true
   datasource:
     url: jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_NAME}
     username: ${DB_USERNAME}


### PR DESCRIPTION
This pull request removes the `show-sql` configuration for both the MySQL and PostgreSQL dialects in the Spring JPA properties. The `format_sql` configuration is also removed. These changes ensure that the SQL queries are not logged in the application logs.