### PR TITLE
Fix security requirement for API endpoints

### DIFF
--- a/src/main/java/org/crochet/controller/BannerController.java
+++ b/src/main/java/org/crochet/controller/BannerController.java
@@ -29,7 +29,7 @@ public class BannerController {
     @ResponseBody
     @PostMapping("/batchInsertOrUpdate")
     @PreAuthorize("hasRole('ADMIN')")
-    @SecurityRequirement(name = "bearerAuth")
+    @SecurityRequirement(name = "BearerAuth")
     public List<BannerResponse> batchInsertOrUpdate(@RequestBody List<BannerRequest> requests) {
         return bannerService.batchInsertOrUpdate(requests);
     }

--- a/src/main/java/org/crochet/controller/BannerTypeController.java
+++ b/src/main/java/org/crochet/controller/BannerTypeController.java
@@ -21,7 +21,7 @@ import java.util.List;
 @RestController
 @RequestMapping("/bannerType")
 @PreAuthorize("hasRole('ADMIN')")
-@SecurityRequirement(name = "bearerAuth")
+@SecurityRequirement(name = "BearerAuth")
 public class BannerTypeController {
     final BannerTypeService bannerTypeService;
 

--- a/src/main/java/org/crochet/controller/BlogCategoryController.java
+++ b/src/main/java/org/crochet/controller/BlogCategoryController.java
@@ -1,10 +1,12 @@
 package org.crochet.controller;
 
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
 import org.crochet.payload.request.BlogCategoryRequest;
 import org.crochet.payload.response.BlogCategoryResponse;
 import org.crochet.service.BlogCategoryService;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -27,6 +29,8 @@ public class BlogCategoryController {
     @PostMapping("/create")
     @ResponseBody
     @ResponseStatus(HttpStatus.CREATED)
+    @PreAuthorize("hasRole('ADMIN')")
+    @SecurityRequirement(name = "BearerAuth")
     public BlogCategoryResponse createBlogCategory(@RequestBody BlogCategoryRequest request) {
         return blogCategoryService.createBlogCategory(request);
     }
@@ -34,12 +38,16 @@ public class BlogCategoryController {
     @PutMapping("/update")
     @ResponseBody
     @ResponseStatus(HttpStatus.OK)
+    @PreAuthorize("hasRole('ADMIN')")
+    @SecurityRequirement(name = "BearerAuth")
     public BlogCategoryResponse updateBlogCategory(@RequestBody BlogCategoryRequest request) {
         return blogCategoryService.updateBlogCategory(request);
     }
 
     @DeleteMapping("/delete/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
+    @PreAuthorize("hasRole('ADMIN')")
+    @SecurityRequirement(name = "BearerAuth")
     public void deleteBlogCategory(@PathVariable String id) {
         blogCategoryService.deleteBlogCategory(id);
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -69,3 +69,6 @@ authorize:
       - "/users/**"
       - "/banner/batchInsertOrUpdate"
       - "/bannerType/**"
+      - "/blog-categories/create"
+      - "/blog-categories/update"
+      - "/blog-categories/delete/**"


### PR DESCRIPTION
This pull request fixes the security requirement for several API endpoints. The `bearerAuth` security requirement has been changed to `BearerAuth` to align with the correct naming convention. This ensures that the endpoints are properly secured.