### PR TITLE
Drop unique category name

### DIFF
--- a/src/main/java/org/crochet/model/Category.java
+++ b/src/main/java/org/crochet/model/Category.java
@@ -25,7 +25,7 @@ import java.util.List;
 @AllArgsConstructor
 @NoArgsConstructor
 public class Category extends BaseEntity {
-    @Column(name = "name", unique = true, nullable = false)
+    @Column(name = "name", nullable = false)
     private String name;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -9,3 +9,5 @@ databaseChangeLog:
       file: src/main/resources/db/migration/2024-05-12-remove-avatar-column-in-blog-table.yaml
   - include:
       file: src/main/resources/db/migration/2024-05-18-add-blog-category-table.yaml
+  - include:
+      file: src/main/resources/db/migration/2024-07-08-drop-unique-constraint-for-name.yaml

--- a/src/main/resources/db/migration/2024-07-08-drop-unique-constraint-for-name.yaml
+++ b/src/main/resources/db/migration/2024-07-08-drop-unique-constraint-for-name.yaml
@@ -1,0 +1,9 @@
+databaseChangeLog:
+  - changeSet:
+      id: DROP_CONSTRAINT_CATEGORY_NAME
+      author: pvanluom
+      changes:
+        - dropUniqueConstraint:
+            columnNames: name
+            constraintName: uc_category_name
+            tableName: category


### PR DESCRIPTION
Remove unique category name. It will cause duplicate errors even if the name is added to a different root.