### PR TITLE
Create initial database schema and address database enhancements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,8 @@ dependencies {
 
     implementation 'org.apache.commons:commons-pool2:2.12.0'
 
+    implementation 'com.github.f4b6a3:tsid-creator:5.2.6'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test:6.3.0'
     testImplementation 'org.mockito:mockito-core:5.11.0'

--- a/src/main/java/org/crochet/model/AuditTable.java
+++ b/src/main/java/org/crochet/model/AuditTable.java
@@ -28,6 +28,7 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 public abstract class AuditTable {
     @CreatedBy
+    @Column(name = "create_by", length = 50)
     private String createdBy;
 
     @CreatedDate
@@ -37,6 +38,7 @@ public abstract class AuditTable {
     private LocalDateTime createdDate;
 
     @LastModifiedBy
+    @Column(name = "last_modified_by", length = 50)
     private String lastModifiedBy;
 
     @LastModifiedDate

--- a/src/main/java/org/crochet/model/AuditTable.java
+++ b/src/main/java/org/crochet/model/AuditTable.java
@@ -28,7 +28,7 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 public abstract class AuditTable {
     @CreatedBy
-    @Column(name = "create_by", length = 50)
+    @Column(name = "created_by", length = 50)
     private String createdBy;
 
     @CreatedDate

--- a/src/main/java/org/crochet/model/BaseEntity.java
+++ b/src/main/java/org/crochet/model/BaseEntity.java
@@ -1,10 +1,10 @@
 package org.crochet.model;
 
+import com.github.f4b6a3.tsid.Tsid;
 import jakarta.persistence.Column;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.PrePersist;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -19,7 +19,11 @@ import lombok.experimental.SuperBuilder;
 @AllArgsConstructor
 public class BaseEntity extends AuditTable {
     @Id
-    @GeneratedValue(strategy = GenerationType.UUID)
-    @Column(name = "id", nullable = false, updatable = false, unique = true)
+    @Column(name = "id", nullable = false, unique = true, length = 50)
     private String id;
+
+    @PrePersist
+    public void init() {
+        this.id = Tsid.fast().toString();
+    }
 }

--- a/src/main/java/org/crochet/model/Collection.java
+++ b/src/main/java/org/crochet/model/Collection.java
@@ -31,10 +31,15 @@ public class Collection extends BaseEntity {
     private String avatar;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", referencedColumnName = "id", nullable = false)
+    @JoinColumn(name = "user_id",
+            referencedColumnName = "id",
+            nullable = false)
     @JsonBackReference
     private User user;
 
-    @OneToMany(mappedBy = "collection", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "collection",
+            cascade = CascadeType.ALL,
+            orphanRemoval = true,
+            fetch = FetchType.LAZY)
     private Set<ColFrep> colfreps = new HashSet<>();
 }

--- a/src/main/java/org/crochet/model/UserProfile.java
+++ b/src/main/java/org/crochet/model/UserProfile.java
@@ -1,18 +1,20 @@
 package org.crochet.model;
 
-import java.time.LocalDate;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.Temporal;
+import jakarta.persistence.TemporalType;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.experimental.SuperBuilder;
+
+import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "user_profile")
@@ -23,15 +25,17 @@ import lombok.experimental.SuperBuilder;
 @AllArgsConstructor
 public class UserProfile extends BaseEntity {
     @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
+    @JoinColumn(name = "user_id", referencedColumnName = "id", nullable = false)
     private User user;
 
     @Column(name = "phone", unique = true)
     private String phone;
 
+    @Temporal(TemporalType.TIMESTAMP)
     @Column(name = "birth_date")
-    private LocalDate birthDate;
+    private LocalDateTime birthDate;
 
+    @Column(name = "gender", length = 10)
     private String gender;
 
     @Column(name = "background_image_url")

--- a/src/main/java/org/crochet/payload/request/UserProfileRequest.java
+++ b/src/main/java/org/crochet/payload/request/UserProfileRequest.java
@@ -1,6 +1,7 @@
 package org.crochet.payload.request;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -15,7 +16,7 @@ public class UserProfileRequest {
     private String name;
     private String imageUrl;
     private String phone;
-    private LocalDate birthDate;
+    private LocalDateTime birthDate;
     private String gender;
     private String backgroundImageUrl;
 }

--- a/src/main/java/org/crochet/payload/response/UserProfileResponse.java
+++ b/src/main/java/org/crochet/payload/response/UserProfileResponse.java
@@ -1,8 +1,10 @@
 package org.crochet.payload.response;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import org.crochet.constant.AppConstant;
 import org.crochet.enumerator.AuthProvider;
 import org.crochet.enumerator.RoleType;
 
@@ -31,7 +33,8 @@ public class UserProfileResponse {
     
     // Profile info
     private String phone;
-    private LocalDate birthDate;
+    @JsonFormat(pattern = AppConstant.DATE_PATTERN)
+    private LocalDateTime birthDate;
     private String gender;
     private String backgroundImageUrl;
     

--- a/src/main/java/org/crochet/repository/CollectionRepo.java
+++ b/src/main/java/org/crochet/repository/CollectionRepo.java
@@ -19,7 +19,7 @@ public interface CollectionRepo extends JpaRepository<Collection, String> {
             LEFT JOIN User u ON u.id = c.user.id
             LEFT JOIN ColFrep cf ON cf.collection.id = c.id
             WHERE u.id = :userId
-            GROUP BY c.id, c.name
+            GROUP BY c.id, c.name, c.avatar
             """)
     List<CollectionResponse> getCollectionsByUserId(@Param("userId") String userId);
 
@@ -29,7 +29,7 @@ public interface CollectionRepo extends JpaRepository<Collection, String> {
             LEFT JOIN User u ON u.id = c.user.id
             LEFT JOIN ColFrep cf ON cf.collection.id = c.id
             WHERE c.id = :cid AND u.id = :userId
-            GROUP BY c.id, c.name
+            GROUP BY c.id, c.name, c.avatar
             """)
     Optional<CollectionResponse> getCollectionByUserId(@Param("cid") String cid, @Param("userId") String userId);
 

--- a/src/main/java/org/crochet/service/impl/ProductServiceImpl.java
+++ b/src/main/java/org/crochet/service/impl/ProductServiceImpl.java
@@ -193,6 +193,7 @@ public class ProductServiceImpl implements ProductService {
      * product.
      */
     @Override
+    @Transactional(readOnly = true)
     public ProductResponse getDetail(String id) {
         var product = productRepo.getDetail(id).orElseThrow(
                 () -> new ResourceNotFoundException(MessageConstant.MSG_PRODUCT_NOT_FOUND,

--- a/src/main/resources/db/migration/Initial_schema.yaml
+++ b/src/main/resources/db/migration/Initial_schema.yaml
@@ -1,0 +1,1220 @@
+databaseChangeLog:
+  - changeSet:
+      id: 1737452201277-1
+      author: luomp
+      objectQuotingStrategy: QUOTE_ONLY_RESERVED_WORDS
+      changes:
+        - createTable:
+            columns:
+              - column:
+                  constraints:
+                    nullable: false
+                    primaryKey: true
+                    primaryKeyName: PRIMARY
+                  name: id
+                  type: VARCHAR(50)
+              - column:
+                  name: created_by
+                  type: VARCHAR(50)
+              - column:
+                  name: created_date
+                  type: datetime
+              - column:
+                  name: last_modified_by
+                  type: VARCHAR(50)
+              - column:
+                  name: last_modified_date
+                  type: datetime
+              - column:
+                  name: title
+                  type: VARCHAR(255)
+              - column:
+                  name: content
+                  type: CLOB
+              - column:
+                  name: url
+                  type: VARCHAR(255)
+              - column:
+                  name: active
+                  type: TINYINT(1)
+              - column:
+                  name: file_name
+                  type: VARCHAR(255)
+              - column:
+                  name: file_content
+                  type: VARCHAR(255)
+              - column:
+                  name: text_color
+                  type: VARCHAR(255)
+              - column:
+                  name: banner_type_id
+                  type: VARCHAR(50)
+            tableName: banner
+  - changeSet:
+      id: 1737452201277-2
+      author: luomp
+      objectQuotingStrategy: QUOTE_ONLY_RESERVED_WORDS
+      changes:
+        - createTable:
+            columns:
+              - column:
+                  name: created_by
+                  type: VARCHAR(50)
+              - column:
+                  name: created_date
+                  type: datetime
+              - column:
+                  name: last_modified_by
+                  type: VARCHAR(50)
+              - column:
+                  name: last_modified_date
+                  type: datetime
+              - column:
+                  name: name
+                  type: VARCHAR(255)
+              - column:
+                  constraints:
+                    nullable: false
+                    primaryKey: true
+                    primaryKeyName: PRIMARY
+                  name: id
+                  type: VARCHAR(50)
+            tableName: banner_type
+  - changeSet:
+      id: 1737452201277-3
+      author: luomp
+      objectQuotingStrategy: QUOTE_ONLY_RESERVED_WORDS
+      changes:
+        - createTable:
+            columns:
+              - column:
+                  name: created_by
+                  type: VARCHAR(50)
+              - column:
+                  name: created_date
+                  type: datetime
+              - column:
+                  name: last_modified_by
+                  type: VARCHAR(50)
+              - column:
+                  name: last_modified_date
+                  type: datetime
+              - column:
+                  name: name
+                  type: VARCHAR(255)
+              - column:
+                  constraints:
+                    nullable: false
+                    primaryKey: true
+                    primaryKeyName: PRIMARY
+                  name: id
+                  type: VARCHAR(50)
+            tableName: blog_category
+  - changeSet:
+      id: 1737452201277-4
+      author: luomp
+      objectQuotingStrategy: QUOTE_ONLY_RESERVED_WORDS
+      changes:
+        - createTable:
+            columns:
+              - column:
+                  name: created_by
+                  type: VARCHAR(50)
+              - column:
+                  name: created_date
+                  type: datetime
+              - column:
+                  name: last_modified_by
+                  type: VARCHAR(50)
+              - column:
+                  name: last_modified_date
+                  type: datetime
+              - column:
+                  name: title
+                  type: VARCHAR(255)
+              - column:
+                  name: content
+                  type: CLOB
+              - column:
+                  name: home
+                  type: TINYINT(1)
+              - column:
+                  constraints:
+                    nullable: false
+                    primaryKey: true
+                    primaryKeyName: PRIMARY
+                  name: id
+                  type: VARCHAR(50)
+              - column:
+                  name: blog_category_id
+                  type: VARCHAR(50)
+            tableName: blog_post
+  - changeSet:
+      id: 1737452201277-5
+      author: luomp
+      objectQuotingStrategy: QUOTE_ONLY_RESERVED_WORDS
+      changes:
+        - createTable:
+            columns:
+              - column:
+                  name: blog_post_id
+                  type: VARCHAR(50)
+              - column:
+                  name: file_name
+                  type: VARCHAR(255)
+              - column:
+                  name: file_content
+                  type: VARCHAR(255)
+              - column:
+                  name: display_order
+                  type: INT
+              - column:
+                  name: last_modified
+                  type: datetime
+            tableName: blog_post_file
+  - changeSet:
+      id: 1737452201277-6
+      author: luomp
+      objectQuotingStrategy: QUOTE_ONLY_RESERVED_WORDS
+      changes:
+        - createTable:
+            columns:
+              - column:
+                  name: created_by
+                  type: VARCHAR(50)
+              - column:
+                  name: created_date
+                  type: datetime
+              - column:
+                  name: last_modified_by
+                  type: VARCHAR(50)
+              - column:
+                  name: last_modified_date
+                  type: datetime
+              - column:
+                  name: name
+                  type: VARCHAR(255)
+              - column:
+                  name: parent_id
+                  type: VARCHAR(50)
+              - column:
+                  constraints:
+                    nullable: false
+                    primaryKey: true
+                    primaryKeyName: PRIMARY
+                  name: id
+                  type: VARCHAR(50)
+            tableName: category
+  - changeSet:
+      id: 1737452201277-7
+      author: luomp
+      objectQuotingStrategy: QUOTE_ONLY_RESERVED_WORDS
+      changes:
+        - createTable:
+            columns:
+              - column:
+                  constraints:
+                    nullable: false
+                    primaryKey: true
+                    primaryKeyName: PRIMARY
+                  name: id
+                  type: VARCHAR(50)
+              - column:
+                  name: created_by
+                  type: VARCHAR(50)
+              - column:
+                  name: created_date
+                  type: datetime
+              - column:
+                  name: last_modified_by
+                  type: VARCHAR(50)
+              - column:
+                  name: last_modified_date
+                  type: datetime
+              - column:
+                  name: name
+                  type: VARCHAR(255)
+              - column:
+                  name: avatar
+                  type: VARCHAR(255)
+              - column:
+                  name: user_id
+                  type: VARCHAR(50)
+            tableName: collection
+  - changeSet:
+      id: 1737452201277-8
+      author: luomp
+      objectQuotingStrategy: QUOTE_ONLY_RESERVED_WORDS
+      changes:
+        - createTable:
+            columns:
+              - column:
+                  constraints:
+                    nullable: false
+                    primaryKey: true
+                    primaryKeyName: PRIMARY
+                  name: id
+                  type: VARCHAR(50)
+              - column:
+                  name: created_by
+                  type: VARCHAR(50)
+              - column:
+                  name: created_date
+                  type: datetime
+              - column:
+                  name: last_modified_by
+                  type: VARCHAR(50)
+              - column:
+                  name: last_modified_date
+                  type: datetime
+              - column:
+                  name: collection_id
+                  type: VARCHAR(50)
+              - column:
+                  name: free_pattern_id
+                  type: VARCHAR(50)
+            tableName: collection_free_pattern
+  - changeSet:
+      id: 1737452201277-9
+      author: luomp
+      objectQuotingStrategy: QUOTE_ONLY_RESERVED_WORDS
+      changes:
+        - createTable:
+            columns:
+              - column:
+                  constraints:
+                    nullable: false
+                    primaryKey: true
+                    primaryKeyName: PRIMARY
+                  name: id
+                  type: VARCHAR(50)
+              - column:
+                  name: created_by
+                  type: VARCHAR(50)
+              - column:
+                  name: created_date
+                  type: datetime
+              - column:
+                  name: last_modified_by
+                  type: VARCHAR(50)
+              - column:
+                  name: last_modified_date
+                  type: datetime
+              - column:
+                  name: post_id
+                  type: VARCHAR(50)
+              - column:
+                  name: user_id
+                  type: VARCHAR(50)
+              - column:
+                  name: content
+                  type: CLOB
+            tableName: comment
+  - changeSet:
+      id: 1737452201277-10
+      author: luomp
+      objectQuotingStrategy: QUOTE_ONLY_RESERVED_WORDS
+      changes:
+        - createTable:
+            columns:
+              - column:
+                  constraints:
+                    nullable: false
+                    primaryKey: true
+                    primaryKeyName: PRIMARY
+                  name: id
+                  type: VARCHAR(50)
+              - column:
+                  name: created_by
+                  type: VARCHAR(50)
+              - column:
+                  name: created_date
+                  type: datetime
+              - column:
+                  name: last_modified_by
+                  type: VARCHAR(50)
+              - column:
+                  name: last_modified_date
+                  type: datetime
+              - column:
+                  name: token
+                  type: VARCHAR(255)
+              - column:
+                  name: expires_at
+                  type: datetime
+              - column:
+                  name: confirmed_at
+                  type: datetime
+              - column:
+                  name: user_id
+                  type: VARCHAR(50)
+            tableName: confirmation_token
+  - changeSet:
+      id: 1737452201277-11
+      author: luomp
+      objectQuotingStrategy: QUOTE_ONLY_RESERVED_WORDS
+      changes:
+        - createTable:
+            columns:
+              - column:
+                  name: created_by
+                  type: VARCHAR(50)
+              - column:
+                  name: created_date
+                  type: datetime
+              - column:
+                  name: last_modified_by
+                  type: VARCHAR(50)
+              - column:
+                  name: last_modified_date
+                  type: datetime
+              - column:
+                  name: name
+                  type: VARCHAR(255)
+              - column:
+                  name: description
+                  type: CLOB
+              - column:
+                  name: author
+                  type: VARCHAR(255)
+              - column:
+                  name: is_home
+                  type: TINYINT(1)
+              - column:
+                  name: link
+                  type: VARCHAR(255)
+              - column:
+                  name: content
+                  type: CLOB
+              - column:
+                  name: status
+                  type: VARCHAR(25)
+              - column:
+                  constraints:
+                    nullable: false
+                    primaryKey: true
+                    primaryKeyName: PRIMARY
+                  name: id
+                  type: VARCHAR(50)
+              - column:
+                  name: category_id
+                  type: VARCHAR(50)
+            tableName: free_pattern
+  - changeSet:
+      id: 1737452201277-12
+      author: luomp
+      objectQuotingStrategy: QUOTE_ONLY_RESERVED_WORDS
+      changes:
+        - createTable:
+            columns:
+              - column:
+                  name: free_pattern_id
+                  type: VARCHAR(50)
+              - column:
+                  name: file_name
+                  type: VARCHAR(255)
+              - column:
+                  name: file_content
+                  type: VARCHAR(255)
+              - column:
+                  name: display_order
+                  type: INT
+              - column:
+                  name: last_modified
+                  type: datetime
+            tableName: free_pattern_file
+  - changeSet:
+      id: 1737452201277-13
+      author: luomp
+      objectQuotingStrategy: QUOTE_ONLY_RESERVED_WORDS
+      changes:
+        - createTable:
+            columns:
+              - column:
+                  name: file_name
+                  type: VARCHAR(255)
+              - column:
+                  name: file_content
+                  type: VARCHAR(255)
+              - column:
+                  name: display_order
+                  type: INT
+              - column:
+                  name: last_modified
+                  type: datetime
+              - column:
+                  name: free_pattern_id
+                  type: VARCHAR(50)
+            tableName: free_pattern_image
+  - changeSet:
+      id: 1737452201277-14
+      author: luomp
+      objectQuotingStrategy: QUOTE_ONLY_RESERVED_WORDS
+      changes:
+        - createTable:
+            columns:
+              - column:
+                  constraints:
+                    nullable: false
+                    primaryKey: true
+                    primaryKeyName: PRIMARY
+                  name: id
+                  type: VARCHAR(50)
+              - column:
+                  name: created_by
+                  type: VARCHAR(50)
+              - column:
+                  name: created_date
+                  type: datetime
+              - column:
+                  name: last_modified_by
+                  type: VARCHAR(50)
+              - column:
+                  name: last_modified_date
+                  type: datetime
+              - column:
+                  name: token
+                  type: VARCHAR(255)
+              - column:
+                  name: expires_at
+                  type: datetime
+              - column:
+                  name: user_id
+                  type: VARCHAR(50)
+            tableName: password_reset_token
+  - changeSet:
+      id: 1737452201277-15
+      author: luomp
+      objectQuotingStrategy: QUOTE_ONLY_RESERVED_WORDS
+      changes:
+        - createTable:
+            columns:
+              - column:
+                  constraints:
+                    nullable: false
+                    primaryKey: true
+                    primaryKeyName: PRIMARY
+                  name: id
+                  type: VARCHAR(50)
+              - column:
+                  name: created_by
+                  type: VARCHAR(50)
+              - column:
+                  name: created_date
+                  type: datetime
+              - column:
+                  name: last_modified_by
+                  type: VARCHAR(50)
+              - column:
+                  name: last_modified_date
+                  type: datetime
+              - column:
+                  name: name
+                  type: VARCHAR(255)
+              - column:
+                  name: description
+                  type: CLOB
+              - column:
+                  name: price
+                  type: DOUBLE
+              - column:
+                  name: currency_code
+                  type: VARCHAR(20)
+              - column:
+                  name: category_id
+                  type: VARCHAR(50)
+              - column:
+                  name: is_home
+                  type: TINYINT(1)
+              - column:
+                  name: link
+                  type: VARCHAR(255)
+              - column:
+                  name: content
+                  type: CLOB
+            tableName: pattern
+  - changeSet:
+      id: 1737452201277-16
+      author: luomp
+      objectQuotingStrategy: QUOTE_ONLY_RESERVED_WORDS
+      changes:
+        - createTable:
+            columns:
+              - column:
+                  name: pattern_id
+                  type: VARCHAR(50)
+              - column:
+                  name: file_name
+                  type: VARCHAR(255)
+              - column:
+                  name: file_content
+                  type: VARCHAR(255)
+              - column:
+                  name: display_order
+                  type: INT
+              - column:
+                  name: last_modified
+                  type: datetime
+            tableName: pattern_file
+  - changeSet:
+      id: 1737452201277-17
+      author: luomp
+      objectQuotingStrategy: QUOTE_ONLY_RESERVED_WORDS
+      changes:
+        - createTable:
+            columns:
+              - column:
+                  name: pattern_id
+                  type: VARCHAR(50)
+              - column:
+                  name: file_name
+                  type: VARCHAR(255)
+              - column:
+                  name: file_content
+                  type: VARCHAR(255)
+              - column:
+                  name: display_order
+                  type: INT
+              - column:
+                  name: last_modified
+                  type: datetime
+            tableName: pattern_image
+  - changeSet:
+      id: 1737452201277-18
+      author: luomp
+      objectQuotingStrategy: QUOTE_ONLY_RESERVED_WORDS
+      changes:
+        - createTable:
+            columns:
+              - column:
+                  name: created_by
+                  type: VARCHAR(50)
+              - column:
+                  name: created_date
+                  type: datetime
+              - column:
+                  name: last_modified_by
+                  type: VARCHAR(50)
+              - column:
+                  name: last_modified_date
+                  type: datetime
+              - column:
+                  name: name
+                  type: VARCHAR(255)
+              - column:
+                  name: description
+                  type: CLOB
+              - column:
+                  name: price
+                  type: DOUBLE
+              - column:
+                  name: currency_code
+                  type: VARCHAR(20)
+              - column:
+                  name: is_home
+                  type: TINYINT(1)
+              - column:
+                  name: link
+                  type: VARCHAR(255)
+              - column:
+                  name: content
+                  type: CLOB
+              - column:
+                  name: category_id
+                  type: VARCHAR(50)
+              - column:
+                  constraints:
+                    nullable: false
+                    primaryKey: true
+                    primaryKeyName: PRIMARY
+                  name: id
+                  type: VARCHAR(50)
+            tableName: product
+  - changeSet:
+      id: 1737452201277-19
+      author: luomp
+      objectQuotingStrategy: QUOTE_ONLY_RESERVED_WORDS
+      changes:
+        - createTable:
+            columns:
+              - column:
+                  name: product_id
+                  type: VARCHAR(255)
+              - column:
+                  name: file_name
+                  type: VARCHAR(255)
+              - column:
+                  name: file_content
+                  type: VARCHAR(255)
+              - column:
+                  name: display_order
+                  type: INT
+              - column:
+                  name: last_modified
+                  type: datetime
+            tableName: product_image
+  - changeSet:
+      id: 1737452201277-20
+      author: luomp
+      objectQuotingStrategy: QUOTE_ONLY_RESERVED_WORDS
+      changes:
+        - createTable:
+            columns:
+              - column:
+                  constraints:
+                    nullable: false
+                    primaryKey: true
+                    primaryKeyName: PRIMARY
+                  name: id
+                  type: VARCHAR(50)
+              - column:
+                  name: created_by
+                  type: VARCHAR(50)
+              - column:
+                  name: created_date
+                  type: datetime
+              - column:
+                  name: last_modified_by
+                  type: VARCHAR(50)
+              - column:
+                  name: last_modified_date
+                  type: datetime
+              - column:
+                  name: token
+                  type: VARCHAR(255)
+              - column:
+                  name: expires_at
+                  type: datetime
+              - column:
+                  name: revoked
+                  type: TINYINT(1)
+              - column:
+                  name: user_id
+                  type: VARCHAR(50)
+            tableName: refresh_token
+  - changeSet:
+      id: 1737452201277-21
+      author: luomp
+      objectQuotingStrategy: QUOTE_ONLY_RESERVED_WORDS
+      changes:
+        - createTable:
+            columns:
+              - column:
+                  constraints:
+                    nullable: false
+                    primaryKey: true
+                    primaryKeyName: PRIMARY
+                  name: setting_key
+                  type: VARCHAR(255)
+              - column:
+                  name: value
+                  type: VARCHAR(255)
+            tableName: settings
+  - changeSet:
+      id: 1737452201277-22
+      author: luomp
+      objectQuotingStrategy: QUOTE_ONLY_RESERVED_WORDS
+      changes:
+        - createTable:
+            columns:
+              - column:
+                  constraints:
+                    nullable: false
+                    primaryKey: true
+                    primaryKeyName: PRIMARY
+                  name: id
+                  type: VARCHAR(50)
+              - column:
+                  name: created_by
+                  type: VARCHAR(50)
+              - column:
+                  name: created_date
+                  type: datetime
+              - column:
+                  name: last_modified_by
+                  type: VARCHAR(50)
+              - column:
+                  name: last_modified_date
+                  type: datetime
+              - column:
+                  name: token
+                  type: VARCHAR(255)
+              - column:
+                  name: blacklisted_at
+                  type: datetime
+            tableName: token_blacklist
+  - changeSet:
+      id: 1737452201277-23
+      author: luomp
+      objectQuotingStrategy: QUOTE_ONLY_RESERVED_WORDS
+      changes:
+        - createTable:
+            columns:
+              - column:
+                  name: created_by
+                  type: VARCHAR(50)
+              - column:
+                  name: created_date
+                  type: datetime
+              - column:
+                  name: last_modified_by
+                  type: VARCHAR(50)
+              - column:
+                  name: last_modified_date
+                  type: datetime
+              - column:
+                  name: phone
+                  type: VARCHAR(20)
+              - column:
+                  name: birth_date
+                  type: CLOB
+              - column:
+                  name: gender
+                  type: VARCHAR(10)
+              - column:
+                  name: background_image_url
+                  type: VARCHAR(255)
+              - column:
+                  name: user_id
+                  type: VARCHAR(50)
+              - column:
+                  constraints:
+                    nullable: false
+                    primaryKey: true
+                    primaryKeyName: PRIMARY
+                  name: id
+                  type: VARCHAR(50)
+            tableName: user_profile
+  - changeSet:
+      id: 1737452201277-24
+      author: luomp
+      objectQuotingStrategy: QUOTE_ONLY_RESERVED_WORDS
+      changes:
+        - createTable:
+            columns:
+              - column:
+                  name: created_by
+                  type: VARCHAR(50)
+              - column:
+                  name: created_date
+                  type: datetime
+              - column:
+                  name: last_modified_by
+                  type: VARCHAR(50)
+              - column:
+                  name: last_modified_date
+                  type: datetime
+              - column:
+                  name: name
+                  type: VARCHAR(255)
+              - column:
+                  name: email
+                  type: VARCHAR(255)
+              - column:
+                  name: image_url
+                  type: VARCHAR(255)
+              - column:
+                  name: email_verified
+                  type: TINYINT(1)
+              - column:
+                  name: password
+                  type: VARCHAR(255)
+              - column:
+                  name: provider
+                  type: VARCHAR(25)
+              - column:
+                  name: provider_id
+                  type: VARCHAR(255)
+              - column:
+                  name: verification_code
+                  type: VARCHAR(255)
+              - column:
+                  name: roles
+                  type: VARCHAR(10)
+              - column:
+                  constraints:
+                    nullable: false
+                    primaryKey: true
+                    primaryKeyName: PRIMARY
+                  name: id
+                  type: VARCHAR(50)
+            tableName: users
+  - changeSet:
+      id: 1737452201277-46
+      author: luomp
+      objectQuotingStrategy: QUOTE_ONLY_RESERVED_WORDS
+      changes:
+        - addForeignKeyConstraint:
+            baseColumnNames: banner_type_id
+            baseTableName: banner
+            constraintName: fk_banner_banner_type_id
+            onDelete: NO ACTION
+            referencedColumnNames: id
+            referencedTableName: banner_type
+        - createIndex:
+            columns:
+              - column:
+                  name: banner_type_id
+            indexName: fk_banner_banner_type_id
+            tableName: banner
+  - changeSet:
+      id: 1737452201277-47
+      author: luomp
+      objectQuotingStrategy: QUOTE_ONLY_RESERVED_WORDS
+      changes:
+        - addForeignKeyConstraint:
+            baseColumnNames: blog_category_id
+            baseTableName: blog_post
+            constraintName: fk_blog_post_blog_category_id
+            onDelete: NO ACTION
+            referencedColumnNames: id
+            referencedTableName: blog_category
+        - createIndex:
+            columns:
+              - column:
+                  name: blog_category_id
+            indexName: fk_blog_post_blog_category_id
+            tableName: blog_post
+  - changeSet:
+      id: 1737452201277-48
+      author: luomp
+      objectQuotingStrategy: QUOTE_ONLY_RESERVED_WORDS
+      changes:
+        - addForeignKeyConstraint:
+            baseColumnNames: blog_post_id
+            baseTableName: blog_post_file
+            constraintName: fk_blog_post_file_blog_post_id
+            onDelete: NO ACTION
+            referencedColumnNames: id
+            referencedTableName: blog_post
+        - createIndex:
+            columns:
+              - column:
+                  name: blog_post_id
+            indexName: fk_blog_post_file_blog_post_id
+            tableName: blog_post_file
+  - changeSet:
+      id: 1737452201277-49
+      author: luomp
+      objectQuotingStrategy: QUOTE_ONLY_RESERVED_WORDS
+      changes:
+        - addForeignKeyConstraint:
+            baseColumnNames: parent_id
+            baseTableName: category
+            constraintName: fk_category_category_id
+            onDelete: NO ACTION
+            referencedColumnNames: id
+            referencedTableName: category
+        - createIndex:
+            columns:
+              - column:
+                  name: parent_id
+            indexName: fk_category_category_id
+            tableName: category
+  - changeSet:
+      id: 1737452201277-50
+      author: luomp
+      objectQuotingStrategy: QUOTE_ONLY_RESERVED_WORDS
+      changes:
+        - addForeignKeyConstraint:
+            baseColumnNames: collection_id
+            baseTableName: collection_free_pattern
+            constraintName: fk_collection_free_pattern_collection_id
+            onDelete: NO ACTION
+            referencedColumnNames: id
+            referencedTableName: collection
+        - createIndex:
+            columns:
+              - column:
+                  name: collection_id
+            indexName: fk_collection_free_pattern_collection_id
+            tableName: collection_free_pattern
+  - changeSet:
+      id: 1737452201277-51
+      author: luomp
+      objectQuotingStrategy: QUOTE_ONLY_RESERVED_WORDS
+      changes:
+        - addForeignKeyConstraint:
+            baseColumnNames: free_pattern_id
+            baseTableName: collection_free_pattern
+            constraintName: fk_collection_free_pattern_free_pattern_id
+            onDelete: NO ACTION
+            referencedColumnNames: id
+            referencedTableName: free_pattern
+        - createIndex:
+            columns:
+              - column:
+                  name: free_pattern_id
+            indexName: fk_collection_free_pattern_free_pattern_id
+            tableName: collection_free_pattern
+  - changeSet:
+      id: 1737452201277-52
+      author: luomp
+      objectQuotingStrategy: QUOTE_ONLY_RESERVED_WORDS
+      changes:
+        - addForeignKeyConstraint:
+            baseColumnNames: user_id
+            baseTableName: collection
+            constraintName: fk_collection_users_id
+            onDelete: NO ACTION
+            referencedColumnNames: id
+            referencedTableName: users
+        - createIndex:
+            columns:
+              - column:
+                  name: user_id
+            indexName: fk_collection_users_id
+            tableName: collection
+  - changeSet:
+      id: 1737452201277-53
+      author: luomp
+      objectQuotingStrategy: QUOTE_ONLY_RESERVED_WORDS
+      changes:
+        - addForeignKeyConstraint:
+            baseColumnNames: post_id
+            baseTableName: comment
+            constraintName: fk_comment_blog_post_id
+            onDelete: NO ACTION
+            referencedColumnNames: id
+            referencedTableName: blog_post
+        - createIndex:
+            columns:
+              - column:
+                  name: post_id
+            indexName: fk_comment_blog_post_id
+            tableName: comment
+  - changeSet:
+      id: 1737452201277-54
+      author: luomp
+      objectQuotingStrategy: QUOTE_ONLY_RESERVED_WORDS
+      changes:
+        - addForeignKeyConstraint:
+            baseColumnNames: user_id
+            baseTableName: comment
+            constraintName: fk_comment_users_id
+            onDelete: NO ACTION
+            referencedColumnNames: id
+            referencedTableName: users
+        - createIndex:
+            columns:
+              - column:
+                  name: user_id
+            indexName: fk_comment_users_id
+            tableName: comment
+  - changeSet:
+      id: 1737452201277-55
+      author: luomp
+      objectQuotingStrategy: QUOTE_ONLY_RESERVED_WORDS
+      changes:
+        - addForeignKeyConstraint:
+            baseColumnNames: user_id
+            baseTableName: confirmation_token
+            constraintName: fk_confirmation_token_users_id
+            onDelete: NO ACTION
+            referencedColumnNames: id
+            referencedTableName: users
+        - createIndex:
+            columns:
+              - column:
+                  name: user_id
+            indexName: fk_confirmation_token_users_id
+            tableName: confirmation_token
+  - changeSet:
+      id: 1737452201277-56
+      author: luomp
+      objectQuotingStrategy: QUOTE_ONLY_RESERVED_WORDS
+      changes:
+        - addForeignKeyConstraint:
+            baseColumnNames: category_id
+            baseTableName: free_pattern
+            constraintName: fk_free_pattern_category_id
+            onDelete: NO ACTION
+            referencedColumnNames: id
+            referencedTableName: category
+        - createIndex:
+            columns:
+              - column:
+                  name: category_id
+            indexName: fk_free_pattern_category_id
+            tableName: free_pattern
+  - changeSet:
+      id: 1737452201277-57
+      author: luomp
+      objectQuotingStrategy: QUOTE_ONLY_RESERVED_WORDS
+      changes:
+        - addForeignKeyConstraint:
+            baseColumnNames: free_pattern_id
+            baseTableName: free_pattern_file
+            constraintName: fk_free_pattern_file_free_pattern_id
+            onDelete: NO ACTION
+            referencedColumnNames: id
+            referencedTableName: free_pattern
+        - createIndex:
+            columns:
+              - column:
+                  name: free_pattern_id
+            indexName: fk_free_pattern_file_free_pattern_id
+            tableName: free_pattern_file
+  - changeSet:
+      id: 1737452201277-58
+      author: luomp
+      objectQuotingStrategy: QUOTE_ONLY_RESERVED_WORDS
+      changes:
+        - addForeignKeyConstraint:
+            baseColumnNames: free_pattern_id
+            baseTableName: free_pattern_image
+            constraintName: fk_free_pattern_image_free_pattern_id
+            onDelete: NO ACTION
+            referencedColumnNames: id
+            referencedTableName: free_pattern
+        - createIndex:
+            columns:
+              - column:
+                  name: free_pattern_id
+            indexName: fk_free_pattern_image_free_pattern_id
+            tableName: free_pattern_image
+  - changeSet:
+      id: 1737452201277-59
+      author: luomp
+      objectQuotingStrategy: QUOTE_ONLY_RESERVED_WORDS
+      changes:
+        - addForeignKeyConstraint:
+            baseColumnNames: user_id
+            baseTableName: password_reset_token
+            constraintName: fk_password_reset_token_users_id
+            onDelete: NO ACTION
+            referencedColumnNames: id
+            referencedTableName: users
+        - createIndex:
+            columns:
+              - column:
+                  name: user_id
+            indexName: fk_password_reset_token_users_id
+            tableName: password_reset_token
+  - changeSet:
+      id: 1737452201277-60
+      author: luomp
+      objectQuotingStrategy: QUOTE_ONLY_RESERVED_WORDS
+      changes:
+        - addForeignKeyConstraint:
+            baseColumnNames: category_id
+            baseTableName: pattern
+            constraintName: fk_pattern_category_id
+            onDelete: NO ACTION
+            referencedColumnNames: id
+            referencedTableName: category
+        - createIndex:
+            columns:
+              - column:
+                  name: category_id
+            indexName: fk_pattern_category_id
+            tableName: pattern
+  - changeSet:
+      id: 1737452201277-61
+      author: luomp
+      objectQuotingStrategy: QUOTE_ONLY_RESERVED_WORDS
+      changes:
+        - addForeignKeyConstraint:
+            baseColumnNames: pattern_id
+            baseTableName: pattern_file
+            constraintName: fk_pattern_file_pattern_id
+            onDelete: NO ACTION
+            referencedColumnNames: id
+            referencedTableName: pattern
+        - createIndex:
+            columns:
+              - column:
+                  name: pattern_id
+            indexName: fk_pattern_file_pattern_id
+            tableName: pattern_file
+  - changeSet:
+      id: 1737452201277-62
+      author: luomp
+      objectQuotingStrategy: QUOTE_ONLY_RESERVED_WORDS
+      changes:
+        - addForeignKeyConstraint:
+            baseColumnNames: pattern_id
+            baseTableName: pattern_image
+            constraintName: fk_pattern_image_pattern_id
+            onDelete: NO ACTION
+            referencedColumnNames: id
+            referencedTableName: pattern
+        - createIndex:
+            columns:
+              - column:
+                  name: pattern_id
+            indexName: fk_pattern_image_pattern_id
+            tableName: pattern_image
+  - changeSet:
+      id: 1737452201277-63
+      author: luomp
+      objectQuotingStrategy: QUOTE_ONLY_RESERVED_WORDS
+      changes:
+        - addForeignKeyConstraint:
+            baseColumnNames: category_id
+            baseTableName: product
+            constraintName: fk_product_category_id
+            onDelete: NO ACTION
+            referencedColumnNames: id
+            referencedTableName: category
+        - createIndex:
+            columns:
+              - column:
+                  name: category_id
+            indexName: fk_product_category_id
+            tableName: product
+  - changeSet:
+      id: 1737452201277-64
+      author: luomp
+      objectQuotingStrategy: QUOTE_ONLY_RESERVED_WORDS
+      changes:
+        - addForeignKeyConstraint:
+            baseColumnNames: product_id
+            baseTableName: product_image
+            constraintName: fk_product_image_product_id
+            onDelete: NO ACTION
+            referencedColumnNames: id
+            referencedTableName: product
+        - createIndex:
+            columns:
+              - column:
+                  name: product_id
+            indexName: fk_product_image_product_id
+            tableName: product_image
+  - changeSet:
+      id: 1737452201277-65
+      author: luomp
+      objectQuotingStrategy: QUOTE_ONLY_RESERVED_WORDS
+      changes:
+        - addForeignKeyConstraint:
+            baseColumnNames: user_id
+            baseTableName: refresh_token
+            constraintName: fk_refresh_token_user_id
+            onDelete: NO ACTION
+            referencedColumnNames: id
+            referencedTableName: users
+        - createIndex:
+            columns:
+              - column:
+                  name: user_id
+            indexName: fk_refresh_token_user_id
+            tableName: refresh_token
+  - changeSet:
+      id: 1737452201277-66
+      author: luomp
+      objectQuotingStrategy: QUOTE_ONLY_RESERVED_WORDS
+      changes:
+        - addForeignKeyConstraint:
+            baseColumnNames: user_id
+            baseTableName: user_profile
+            constraintName: fk_user_profile_user_id
+            onDelete: NO ACTION
+            referencedColumnNames: id
+            referencedTableName: users
+        - createIndex:
+            columns:
+              - column:
+                  name: user_id
+            indexName: fk_user_profile_user_id
+            tableName: user_profile
+


### PR DESCRIPTION
### Summary
This pull request includes the following changes:
- Establishes the initial database schema with core tables (`users`, `banner`, `blog_post`, `product`, and related entities).
- Adds necessary foreign key constraints and indexes to support referential integrity.
- Ensures the `getDetail` method operates under a `@Transactional(readOnly = true)` context to safeguard against unintended write operations.
- Corrects a column name typo in the `AuditTable` entity from `create_by` to `created_by`.
- Refactors ID generation to use `Tsid`, introduces `@PrePersist` mechanisms, and updates entity attributes (e.g., `birthDate` data type and column specifications).
- Adjusts repository queries to account for grouping modifications in `Collection