### PR TITLE
Fixing shared collection reference

### DIFF
--- a/src/main/java/org/crochet/controller/CategoryController.java
+++ b/src/main/java/org/crochet/controller/CategoryController.java
@@ -51,7 +51,7 @@ public class CategoryController {
             @ApiResponse(responseCode = "500", description = "Internal server error",
                     content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ResponseData.class))})
     })
-    @PreAuthorize("hasRole('ADMIN')")
+    @PreAuthorize("hasAnyRole('ADMIN', 'USER')")
     @SecurityRequirement(name = "BearerAuth")
     @PostMapping("/create")
     public ResponseEntity<List<CategoryResponse>> create(@Valid @RequestBody CategoryCreationRequest request) {
@@ -72,7 +72,7 @@ public class CategoryController {
             @ApiResponse(responseCode = "500", description = "Internal server error",
                     content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ResponseData.class))})
     })
-    @PreAuthorize("hasRole('ADMIN')")
+    @PreAuthorize("hasAnyRole('ADMIN', 'USER')")
     @SecurityRequirement(name = "BearerAuth")
     @PutMapping("/update")
     public ResponseEntity<CategoryResponse> update(@Valid @RequestBody CategoryUpdateRequest request) {
@@ -106,7 +106,7 @@ public class CategoryController {
     @ApiResponse(responseCode = "400", description = "Bad request",
             content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ResponseData.class))})
     @DeleteMapping("/delete")
-    @PreAuthorize("hasRole('ADMIN')")
+    @PreAuthorize("hasAnyRole('ADMIN', 'USER')")
     @SecurityRequirement(name = "BearerAuth")
     public ResponseData<String> delete(@RequestParam String id) {
         categoryService.delete(id);

--- a/src/main/java/org/crochet/mapper/BlogPostMapper.java
+++ b/src/main/java/org/crochet/mapper/BlogPostMapper.java
@@ -3,6 +3,7 @@ package org.crochet.mapper;
 import org.crochet.model.BlogPost;
 import org.crochet.payload.request.BlogPostRequest;
 import org.crochet.payload.response.BlogPostResponse;
+import org.crochet.util.ImageUtils;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.ReportingPolicy;
@@ -28,5 +29,26 @@ public interface BlogPostMapper extends PartialUpdate<BlogPost, BlogPostRequest>
                         .map(this::toResponse)
                         .toList())
                 .orElse(null);
+    }
+
+    @Override
+    default BlogPost partialUpdate(BlogPostRequest request, BlogPost post) {
+        if (post == null) {
+            return null;
+        }
+        if (request.getTitle() != null) {
+            post.setTitle(request.getTitle());
+        }
+        if (request.getContent() != null) {
+            post.setContent(request.getContent());
+        }
+        if (request.isHome() != post.isHome()) {
+            post.setHome(request.isHome());
+        }
+        if (request.getFiles() != null) {
+            var sortedFiles = ImageUtils.sortFiles(request.getFiles());
+            post.setFiles(FileMapper.INSTANCE.toEntities(sortedFiles));
+        }
+        return post;
     }
 }

--- a/src/main/java/org/crochet/mapper/FreePatternMapper.java
+++ b/src/main/java/org/crochet/mapper/FreePatternMapper.java
@@ -3,6 +3,7 @@ package org.crochet.mapper;
 import org.crochet.model.FreePattern;
 import org.crochet.payload.request.FreePatternRequest;
 import org.crochet.payload.response.FreePatternResponse;
+import org.crochet.util.ImageUtils;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.ReportingPolicy;
@@ -15,11 +16,47 @@ import java.util.List;
         unmappedTargetPolicy = ReportingPolicy.IGNORE,
         uses = {FileMapper.class, CategoryMapper.class}
 )
-public interface FreePatternMapper extends PartialUpdate<FreePattern, FreePatternRequest> {
+public interface FreePatternMapper {
     FreePatternMapper INSTANCE = Mappers.getMapper(FreePatternMapper.class);
 
     @Mapping(target = "isHome", source = "home")
     FreePatternResponse toResponse(FreePattern pattern);
 
     List<FreePatternResponse> toResponses(Collection<FreePattern> freePatterns);
+
+    default FreePattern update(FreePatternRequest req, FreePattern freePattern) {
+        if (freePattern == null) {
+            return null;
+        }
+        if (req.getName() != null) {
+            freePattern.setName(req.getName());
+        }
+        if (req.getDescription() != null) {
+            freePattern.setDescription(req.getDescription());
+        }
+        if (req.getAuthor() != null) {
+            freePattern.setAuthor(req.getAuthor());
+        }
+        if (req.isHome() != freePattern.isHome()) {
+            freePattern.setHome(req.isHome());
+        }
+        if (req.getLink() != null) {
+            freePattern.setLink(req.getLink());
+        }
+        if (req.getContent() != null) {
+            freePattern.setContent(req.getContent());
+        }
+        if (req.getStatus() != null) {
+            freePattern.setStatus(req.getStatus());
+        }
+        if (req.getImages() != null && !req.getImages().isEmpty()) {
+            var sortedImages = ImageUtils.sortFiles(req.getImages());
+            freePattern.setImages(FileMapper.INSTANCE.toEntities(sortedImages));
+        }
+        if (req.getFiles() != null && !req.getFiles().isEmpty()) {
+            var sortedFiles = ImageUtils.sortFiles(req.getFiles());
+            freePattern.setFiles(FileMapper.INSTANCE.toSetEntities(sortedFiles));
+        }
+        return freePattern;
+    }
 }

--- a/src/main/java/org/crochet/mapper/PatternMapper.java
+++ b/src/main/java/org/crochet/mapper/PatternMapper.java
@@ -3,6 +3,7 @@ package org.crochet.mapper;
 import org.crochet.model.Pattern;
 import org.crochet.payload.request.PatternRequest;
 import org.crochet.payload.response.PatternResponse;
+import org.crochet.util.ImageUtils;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.ReportingPolicy;
@@ -21,6 +22,43 @@ public interface PatternMapper extends PartialUpdate<Pattern, PatternRequest> {
     @Mapping(target = "isHome", source = "home")
     @Mapping(target = "currencyCode", source = "currencyCode")
     PatternResponse toResponse(Pattern pattern);
+
+    @Override
+    default Pattern partialUpdate(PatternRequest req, Pattern pattern) {
+        if (pattern == null) {
+            return null;
+        }
+        if (req.getName() != null) {
+            pattern.setName(req.getName());
+        }
+        if (req.getDescription() != null) {
+            pattern.setDescription(req.getDescription());
+        }
+        if (req.getPrice() != pattern.getPrice()) {
+            pattern.setPrice(req.getPrice());
+        }
+        if (req.getCurrencyCode() != null) {
+            pattern.setCurrencyCode(req.getCurrencyCode());
+        }
+        if (req.isHome() != pattern.isHome()) {
+            pattern.setHome(req.isHome());
+        }
+        if (req.getLink() != null) {
+            pattern.setLink(req.getLink());
+        }
+        if (req.getContent() != null) {
+            pattern.setContent(req.getContent());
+        }
+        if (req.getImages() != null && !req.getImages().isEmpty()) {
+            var sortedImages = ImageUtils.sortFiles(req.getImages());
+            pattern.setImages(FileMapper.INSTANCE.toEntities(sortedImages));
+        }
+        if (req.getFiles() != null && !req.getFiles().isEmpty()) {
+            var sortedFiles = ImageUtils.sortFiles(req.getFiles());
+            pattern.setFiles(FileMapper.INSTANCE.toSetEntities(sortedFiles));
+        }
+        return pattern;
+    }
 
     List<PatternResponse> toResponses(Collection<Pattern> patterns);
 }

--- a/src/main/java/org/crochet/mapper/ProductMapper.java
+++ b/src/main/java/org/crochet/mapper/ProductMapper.java
@@ -3,11 +3,9 @@ package org.crochet.mapper;
 import org.crochet.model.Product;
 import org.crochet.payload.request.ProductRequest;
 import org.crochet.payload.response.ProductResponse;
-import org.mapstruct.BeanMapping;
+import org.crochet.util.ImageUtils;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
-import org.mapstruct.MappingTarget;
-import org.mapstruct.NullValuePropertyMappingStrategy;
 import org.mapstruct.ReportingPolicy;
 import org.mapstruct.factory.Mappers;
 
@@ -27,7 +25,35 @@ public interface ProductMapper {
 
     List<ProductResponse> toResponses(Collection<Product> products);
 
-    @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
-    @Mapping(target = "id", ignore = true)
-    Product update(ProductRequest request, @MappingTarget Product product);
+    default Product update(ProductRequest request, Product product) {
+        if (product == null) {
+            return null;
+        }
+        if (request.getName() != null) {
+            product.setName(request.getName());
+        }
+        if (request.getDescription() != null) {
+            product.setDescription(request.getDescription());
+        }
+        if (request.getPrice() != product.getPrice()) {
+            product.setPrice(request.getPrice());
+        }
+        if (request.getCurrencyCode() != null) {
+            product.setCurrencyCode(request.getCurrencyCode());
+        }
+        if (request.isHome() != product.isHome()) {
+            product.setHome(request.isHome());
+        }
+        if (request.getLink() != null) {
+            product.setLink(request.getLink());
+        }
+        if (request.getContent() != null) {
+            product.setContent(request.getContent());
+        }
+        if (request.getImages() != null && !request.getImages().isEmpty()) {
+            var sortedImages = ImageUtils.sortFiles(request.getImages());
+            product.setImages(FileMapper.INSTANCE.toEntities(sortedImages));
+        }
+        return product;
+    }
 }

--- a/src/main/java/org/crochet/model/BaseEntity.java
+++ b/src/main/java/org/crochet/model/BaseEntity.java
@@ -13,7 +13,7 @@ import lombok.experimental.SuperBuilder;
 
 @Getter
 @Setter
-@SuperBuilder
+@SuperBuilder(toBuilder = true)
 @MappedSuperclass
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/org/crochet/service/impl/BlogPostServiceImpl.java
+++ b/src/main/java/org/crochet/service/impl/BlogPostServiceImpl.java
@@ -64,7 +64,6 @@ public class BlogPostServiceImpl implements BlogPostService {
     @Override
     public void createOrUpdatePost(BlogPostRequest request) {
         BlogPost blogPost;
-        var images = ImageUtils.sortFiles(request.getFiles());
 
         if (!StringUtils.hasText(request.getId())) {
             BlogCategory blogCategory = null;
@@ -73,6 +72,7 @@ public class BlogPostServiceImpl implements BlogPostService {
                         .orElseThrow(() -> new ResourceNotFoundException(MessageConstant.MSG_BLOG_CATEGORY_NOT_FOUND,
                                 MAP_CODE.get(MessageConstant.MSG_BLOG_CATEGORY_NOT_FOUND)));
             }
+            var images = ImageUtils.sortFiles(request.getFiles());
             blogPost = BlogPost.builder()
                     .blogCategory(blogCategory)
                     .title(request.getTitle())
@@ -82,12 +82,7 @@ public class BlogPostServiceImpl implements BlogPostService {
                     .build();
         } else {
             blogPost = getById(request.getId());
-            blogPost = blogPost.toBuilder()
-                    .title(request.getTitle())
-                    .content(request.getContent())
-                    .home(request.isHome())
-                    .files(FileMapper.INSTANCE.toEntities(images))
-                    .build();
+            blogPost = BlogPostMapper.INSTANCE.partialUpdate(request, blogPost);
         }
         blogPostRepo.save(blogPost);
     }

--- a/src/main/java/org/crochet/service/impl/FreePatternServiceImpl.java
+++ b/src/main/java/org/crochet/service/impl/FreePatternServiceImpl.java
@@ -8,6 +8,7 @@ import org.crochet.exception.AccessDeniedException;
 import org.crochet.exception.ResourceNotFoundException;
 import org.crochet.mapper.CategoryMapper;
 import org.crochet.mapper.FileMapper;
+import org.crochet.mapper.FreePatternMapper;
 import org.crochet.model.FreePattern;
 import org.crochet.payload.request.Filter;
 import org.crochet.payload.request.FreePatternRequest;
@@ -60,14 +61,12 @@ public class FreePatternServiceImpl implements FreePatternService {
     @Override
     public void createOrUpdate(FreePatternRequest request) {
         FreePattern freePattern;
-        var sortedImages = ImageUtils.sortFiles(request.getImages());
-        var sortedFiles = ImageUtils.sortFiles(request.getFiles());
-
         if (!StringUtils.hasText(request.getId())) {
             var category = categoryRepo.findCategoryById(request.getCategoryId())
                     .orElseThrow(() -> new ResourceNotFoundException(MessageConstant.MSG_CATEGORY_NOT_FOUND,
                             MAP_CODE.get(MessageConstant.MSG_CATEGORY_NOT_FOUND)));
-
+            var sortedImages = ImageUtils.sortFiles(request.getImages());
+            var sortedFiles = ImageUtils.sortFiles(request.getFiles());
             freePattern = FreePattern.builder()
                     .category(category)
                     .name(request.getName())
@@ -84,17 +83,7 @@ public class FreePatternServiceImpl implements FreePatternService {
             freePattern = freePatternRepo.findById(request.getId()).orElseThrow(
                     () -> new ResourceNotFoundException(MessageConstant.MSG_FREE_PATTERN_NOT_FOUND,
                             MAP_CODE.get(MessageConstant.MSG_FREE_PATTERN_NOT_FOUND)));
-            freePattern = freePattern.toBuilder()
-                    .name(request.getName())
-                    .description(request.getDescription())
-                    .author(request.getAuthor())
-                    .isHome(request.isHome())
-                    .link(request.getLink())
-                    .content(request.getContent())
-                    .status(request.getStatus())
-                    .files(FileMapper.INSTANCE.toSetEntities(sortedFiles))
-                    .images(FileMapper.INSTANCE.toEntities(sortedImages))
-                    .build();
+            freePattern = FreePatternMapper.INSTANCE.update(request, freePattern);
         }
         freePatternRepo.save(freePattern);
     }

--- a/src/main/java/org/crochet/service/impl/PatternServiceImpl.java
+++ b/src/main/java/org/crochet/service/impl/PatternServiceImpl.java
@@ -53,13 +53,13 @@ public class PatternServiceImpl implements PatternService {
     @Override
     public void createOrUpdate(PatternRequest request) {
         Pattern pattern;
-        var images = ImageUtils.sortFiles(request.getImages());
-        var files = ImageUtils.sortFiles(request.getFiles());
 
         if (!StringUtils.hasText(request.getId())) {
             var category = categoryRepo.findById(request.getCategoryId()).orElseThrow(
                     () -> new ResourceNotFoundException(MessageConstant.MSG_CATEGORY_NOT_FOUND,
                             MAP_CODE.get(MessageConstant.MSG_CATEGORY_NOT_FOUND)));
+            var images = ImageUtils.sortFiles(request.getImages());
+            var files = ImageUtils.sortFiles(request.getFiles());
             pattern = Pattern.builder()
                     .category(category)
                     .name(request.getName())
@@ -76,17 +76,7 @@ public class PatternServiceImpl implements PatternService {
             pattern = patternRepo.findById(request.getId()).orElseThrow(
                     () -> new ResourceNotFoundException(MessageConstant.MSG_PATTERN_NOT_FOUND,
                             MAP_CODE.get(MessageConstant.MSG_PATTERN_NOT_FOUND)));
-            pattern = pattern.toBuilder()
-                    .name(request.getName())
-                    .description(request.getDescription())
-                    .price(request.getPrice())
-                    .currencyCode(request.getCurrencyCode())
-                    .isHome(request.isHome())
-                    .link(request.getLink())
-                    .content(request.getContent())
-                    .files(FileMapper.INSTANCE.toSetEntities(files))
-                    .images(FileMapper.INSTANCE.toEntities(images))
-                    .build();
+            pattern = PatternMapper.INSTANCE.partialUpdate(request, pattern);
         }
 
         patternRepo.save(pattern);

--- a/src/main/java/org/crochet/service/impl/ProductServiceImpl.java
+++ b/src/main/java/org/crochet/service/impl/ProductServiceImpl.java
@@ -58,13 +58,12 @@ public class ProductServiceImpl implements ProductService {
     @Override
     public void createOrUpdate(ProductRequest request) {
         Product product;
-        var images = ImageUtils.sortFiles(request.getImages());
-
         if (!StringUtils.hasText(request.getId())) {
             var category = categoryRepo.findById(request.getCategoryId()).orElseThrow(
                     () -> new ResourceNotFoundException(MessageConstant.MSG_CATEGORY_NOT_FOUND,
                             MAP_CODE.get(MessageConstant.MSG_CATEGORY_NOT_FOUND)));
 
+            var images = ImageUtils.sortFiles(request.getImages());
             product = Product.builder()
                     .category(category)
                     .name(request.getName())
@@ -80,15 +79,7 @@ public class ProductServiceImpl implements ProductService {
             product = productRepo.findById(request.getId())
                     .orElseThrow(() -> new ResourceNotFoundException(MessageConstant.MSG_PRODUCT_NOT_FOUND,
                             MAP_CODE.get(MessageConstant.MSG_PRODUCT_NOT_FOUND)));
-            product = product.toBuilder()
-                    .name(request.getName())
-                    .description(request.getDescription())
-                    .price(request.getPrice())
-                    .currencyCode(request.getCurrencyCode())
-                    .isHome(request.isHome())
-                    .link(request.getLink())
-                    .images(FileMapper.INSTANCE.toEntities(images))
-                    .build();
+            product = ProductMapper.INSTANCE.update(request, product);
         }
         productRepo.save(product);
     }


### PR DESCRIPTION
Enable toBuilder option for BaseEntity, allow both ADMIN and USER roles to access category endpoints, and refactor update logic for FreePattern, BlogPost, and Product entities to streamline partial updates.