### PR TITLE
Fixing refresh token auth fail

### DIFF
--- a/src/main/java/org/crochet/repository/RefreshTokenRepo.java
+++ b/src/main/java/org/crochet/repository/RefreshTokenRepo.java
@@ -2,6 +2,7 @@ package org.crochet.repository;
 
 import org.crochet.model.RefreshToken;
 import org.crochet.model.User;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -11,6 +12,7 @@ import java.util.Optional;
 
 @Repository
 public interface RefreshTokenRepo extends JpaRepository<RefreshToken, String> {
+    @EntityGraph(attributePaths = {"user"})
     Optional<RefreshToken> findByToken(String token);
 
     @Query("""

--- a/src/main/java/org/crochet/service/impl/AuthServiceImpl.java
+++ b/src/main/java/org/crochet/service/impl/AuthServiceImpl.java
@@ -382,7 +382,7 @@ public class AuthServiceImpl implements AuthService {
                 .map(refreshTokenService::verifyExpiration)
                 .map(RefreshToken::getUser)
                 .map(user -> {
-                    String accessToken = jwtTokenService.generateToken(user.getEmail());
+                    String accessToken = jwtTokenService.generateToken(user.getId());
                     return TokenResponse.builder()
                             .accessToken(accessToken)
                             .refreshToken(refreshToken)


### PR DESCRIPTION
**Cause:**
Using refresh token does not work, although the token has been created, but when using that token, when requesting with user or admin role, it says it is not authenticated.
![CannotInitializeProxy](https://github.com/user-attachments/assets/d42586b2-c8ec-4d9c-aa0b-54968ce5b7a8)

**Solution:**
Because refresh creates token is getEmail not getId