### PR TITLE
Fixing Missing Username on Free Pattern Detail Page

### DIFF
--- a/src/main/java/org/crochet/service/impl/FreePatternServiceImpl.java
+++ b/src/main/java/org/crochet/service/impl/FreePatternServiceImpl.java
@@ -219,7 +219,7 @@ public class FreePatternServiceImpl implements FreePatternService {
                 .content(frep.getContent())
                 .status(frep.getStatus())
                 .userId(user.getId())
-                .username(user.getUsername())
+                .username(user.getName())
                 .userAvatar(user.getImageUrl())
                 .images(images)
                 .files(files)


### PR DESCRIPTION
**Bug Description:**
The user's name is not displayed on the free pattern detail page; instead, the user ID is shown.

**Cause:**
Currently, the system returns `user.getUsername()` instead of `user.getName()`.

**Solution:**
In the detail function of the free pattern, replace `user.getUsername()` with `user.getName()`.

**Result After Fix:**
![{2C61D2A7-9E01-4454-B086-10B43BFA3BBC}](https://github.com/user-attachments/assets/376496f1-d90e-4d0b-96ee-4128cf43c914)