### PR TITLE
Fixing User profile Extra Queries

### DIFF
--- a/src/main/java/org/crochet/repository/UserRepository.java
+++ b/src/main/java/org/crochet/repository/UserRepository.java
@@ -2,6 +2,10 @@ package org.crochet.repository;
 
 import org.crochet.model.User;
 import org.crochet.payload.response.UserResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Modifying;
@@ -15,6 +19,9 @@ import java.util.Optional;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, String>, JpaSpecificationExecutor<User> {
+
+    @EntityGraph(attributePaths = {"userProfile"})
+    Page<User> findAll(Specification<User> spec, Pageable pageable);
 
     Optional<User> findByEmail(String email);
 


### PR DESCRIPTION
### Bug Description:
When retrieving all users, their profiles are also fetched individually by ID.

### Cause:
Since there is a one-to-one relationship between `User ` and `UserProfile`, the User entity eagerly fetches the `UserProfile`, leading to the described issue.

### Solution:
Use `@EntityGraph(attributes = {"userProfile"})` to fetch `UserProfile `in a single query, effectively resolving the issue.

**Before Fix:**
(Log output before applying the fix)
[before-fix.txt](https://github.com/user-attachments/files/18882377/before-fix.txt)

**After Fix:**
(Log output after applying the fix)
[after-fix.txt](https://github.com/user-attachments/files/18882381/after-fix.txt)